### PR TITLE
Fix LICENSE.md file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,18 +2,17 @@
 
 Copyright Nabu Casa 2023
 
-This source describes Open Hardware and is licensed under the CERN-OHL-S v2.
+This source describes Open Hardware and is licensed under the CERN-OHL-W v2.
 
-You may redistribute and modify this source and make products using it under
-the terms of the CERN-OHL-S v2 (cern_ohl_s_v2.txt in this repository).
+You may redistribute and modify this documentation and make products using it
+under the terms of the CERN-OHL-W v2 (cern_ohl_w_v2.txt in this repository).
 
-This source is distributed WITHOUT ANY EXPRESS OR IMPLIED WARRANTY,
+This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED WARRANTY,
 INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY AND FITNESS FOR A
-PARTICULAR PURPOSE. Please see the CERN-OHL-S v2 for applicable conditions.
+PARTICULAR PURPOSE. Please see the CERN-OHL-W v2 for applicable conditions.
 
 Source location: https://github.com/NabuCasa/yellow
 
-As per CERN-OHL-S v2 section 4, should You produce hardware based on this
-source, You must where practicable maintain the Source Location visible
-on the external case of the Gizmo or other products you make using this
-source.
+As per CERN-OHL-W v2 section 4.1, should You produce hardware based on these
+sources, You must maintain the Source Location visible on the external case
+of the Yellow or other product you make using this documentation.


### PR DESCRIPTION
The project was meant to be licensed under the CERN-OHL-W v2.

Fixes: #65